### PR TITLE
Update link to `grafana-pandas-datasource`, the Python/pandas backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ information.
 - https://github.com/bergquist/fake-simple-json-datasource
 - https://github.com/smcquay/jsonds
 - https://github.com/ContextLogic/eventmaster
-- https://gist.github.com/linar-jether/95ff412f9d19fdf5e51293eb0c09b850 (Python/pandas backend)
+- https://github.com/panodata/grafana-pandas-datasource (Python/pandas backend)
 
 ### Query API
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -30,7 +30,7 @@ information.
 - https://github.com/bergquist/fake-simple-json-datasource
 - https://github.com/smcquay/jsonds
 - https://github.com/ContextLogic/eventmaster
-- https://gist.github.com/linar-jether/95ff412f9d19fdf5e51293eb0c09b850 (Python/pandas backend)
+- https://github.com/panodata/grafana-pandas-datasource (Python/pandas backend)
 
 ### Query API
 


### PR DESCRIPTION
Hi,

this patch updates a link in the README document to the Python/pandas datasource [^1].

I already found #172 where it is recommended to use one of those plugins instead:

> - [JSON](https://grafana.com/grafana/plugins/simpod-json-datasource) by Šimon Podlipský
> - [JSON API](https://grafana.com/grafana/plugins/marcusolsson-json-datasource) by Marcus Olsson

On this matter, I hope to be able to find some time soon.

With kind regards,
Andreas.

[^1]: https://github.com/panodata/grafana-pandas-datasource
