### PR TITLE
deprecation

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,7 +1,83 @@
 # Migration Guide
 
-This plugin is now deprecated and **no longer maintained** by the Grafana team. You can use [Grafana Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) as an alternative for connecting to JSON/CSV/XML/GraphQL endpoints. Refer the migration guide [here](https://github.com/grafana/grafana-infinity-datasource/discussions/740), if you still prefer connecting to existing grafana simple JSON backend server implementation. This deprecation means that this plugin won't receive any feature updates or bug fixes. After 6 months (End of June 2024), the plugin will reach EOL and the repository will be archived.
+This plugin is now deprecated and **no longer maintained** by the Grafana team. This deprecation means that this plugin won't receive any feature updates or bug fixes. After 6 months (End of June 2024), the plugin will reach EOL and the repository will be archived. You can use [Grafana Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) as an alternative for connecting to JSON/CSV/XML/GraphQL endpoints. Refer the migration guide [here](https://github.com/grafana/grafana-infinity-datasource/discussions/740), if you still prefer connecting to existing grafana simple JSON backend server implementation. Alternatively, you can also build your own plugin.
 
 ## Building your own plugin
 
  If you are looking for building your own plugin, consider the examples [here](https://github.com/grafana/grafana-plugin-examples) and documentation [here](https://grafana.com/developers).
+
+## Migrating to Infinity data source plugin
+
+<p align="center">
+<img src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/7319d1c5-8e5a-4a4a-bf2f-66e37f9a98f5" width="100" height="100" /><b>=></b>
+<img src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/9f38194c-0033-4764-8553-0c5f0268ab4d"  width="120" height="120" />
+</p>
+
+> [!IMPORTANT]
+> Infinity is not a drop-in replacement for simple JSON datasource plugin. This require manual migration efforts. But migrating to infinity is strongly recommended approach if you are using simple JSON API datasource plugin.
+
+### Approach 1: Direct API connection / Simple approach / Recommended approach
+
+This is much easier and **recommended approach** to connect JSON api endpoints directly. Infinity allows you to connect directly to your JSON endpoints instead of requiring you to write your server implementation comparing to grafana simple json server approach. Refer [Infinity plugin website](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) for more details about connecting your APIs directly.
+
+With this approach, you can get rid of your custom json server and directly connect your API endpoints via Infinity plugin. If this approach is not possible for any reason, use the below alternate migration approach.
+
+### Approach 2: Migrating using Grafana simple json server approach
+
+With this approach, Instead of connecting your API endpoints directly, you will be connecting via grafana simple JSON server (legacy server). Also in grafana, instead of using simple json datasource plugin, you will be using Infinity plugin. 
+
+#### Migrating the configuration
+
+In terms of configuration editor, there is no much change. The URL used in simple json datasource goes into infinity config misc/url section. Other options such as proxy, tls/ca certificates, headers goes into network and headers section.
+
+| Before | After |
+|--|--|
+| <img width="817" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/f7381eaa-8791-49e1-b114-d69e40876f26"> | <img width="881" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/f064f74c-7302-4518-8102-4e0a0c92a500">|
+
+#### Provisioning
+
+Provisioning of simple json and infinity is almost similar only the plugin id differs. Refer the infinity plugin [provisioning documentation](https://grafana.com/docs/plugins/yesoreyeram-infinity-datasource/latest/setup/provisioning/) for more examples.
+
+| Before | After |
+|--|--|
+| <img width="424" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/455cd3e0-2e71-4f26-8a66-6da978532609"> | <img width="417" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/ff63244e-5ba2-4642-9321-8efddd8898a0">|
+
+
+#### Migrating the queries ( quick migration / frontend parser )
+
+If you are using one or more queries using Simple JSON as shown below, you can migrate to infinity using the steps provided below. This approach is simple but less powerful. Doesn't support grafana backend features such as alerting.
+
+| Before | After |
+|---|---|
+| <img width="1326" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/2d26e1cc-2ed1-488e-9607-0bd5226785a9">| <img width="1335" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/be3e07a9-4d7b-45b0-9cb6-e7ef86b74d99"><img width="1299" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/74cc2435-4bfb-444d-83ce-62198a46e0bc">|
+| Select the target in the query editor. Example `upper_25`| Select `JSON` as query type. <br/>Select `Default`/`Frontend` as your parser. <br/>Source: `URL`. <br/>Format: `As IS`/`Legacy`. <br/>HTTP Method: `POST`. <br/>URL : `/query`<br/>HTTP Body: In your http body you need to specify the targets: `{  "targets": [{ "target":"upper_25" }] }`| 
+
+
+#### Migrating the queries ( recommended migration / backend parser )
+
+Use this approach to migrate to get support for features such as alerting, public dashboards, query caching etc.
+
+| Before | After |
+|---|--|
+|<img width="1319" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/2a619d89-d15f-4bc0-a6c3-d958ec2d74da">|<img width="1314" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/04e531c3-00f9-44de-8429-0850a4541cad"><img width="876" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/f1771ff6-fa93-4c43-8933-5727e2116c31">|
+|Select the target in the query editor. Example `upper_25`|Query Type: `URL` <br/>Parser: `Backend` <br/>Source: `URL` <br/>Format: `Time series` <br/>HTTP method: `POST` <br/>URL: `/query` <br/>BODY: `{  "targets": [{ "target":"upper_25" }]}` <br/>Parsing options/Root: `datapoints` <br/> Column 1: `0` as selector. `upper_25` as alias. `Number` as format.<br/>Column 2: `1` as selector. `Time` as alias. `Unix (ms)` as format.<br/>|
+
+### Migrating the annotations
+
+Migrating the annotations is similar to query. For example, below screenoshots show different annotation creations
+
+###### Using Simple JSON
+<img width="631" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/471fffe5-ef35-43b0-93a1-c6e666244ef4">
+
+###### Using Infinity
+<img width="1385" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/216138f6-b7d7-4911-93fb-f30da94b9efe">
+
+
+#### Troubleshooting
+
+> [!NOTE]
+> Infinity doesn't support direct browser connection to your API endpoints. All the requests will be proxied from grafana server.
+
+#### Sample migration dashboard
+
+<img width="1792" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/24038bad-2dbf-474a-b0e6-63405092057a" />

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,7 @@
+# Migration Guide
+
+This plugin is now deprecated and **no longer maintained** by the Grafana team. You can use [Grafana Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) as an alternative for connecting to JSON/CSV/XML/GraphQL endpoints. Refer the migration guide [here](https://github.com/grafana/grafana-infinity-datasource/discussions/740), if you still prefer connecting to existing grafana simple JSON backend server implementation. This deprecation means that this plugin won't receive any feature updates or bug fixes. After 6 months (End of June 2024), the plugin will reach EOL and the repository will be archived.
+
+## Building your own plugin
+
+ If you are looking for building your own plugin, consider the examples [here](https://github.com/grafana/grafana-plugin-examples) and documentation [here](https://grafana.com/developers).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-## Simple JSON Datasource - a generic backend datasource
+# Deprecated plugin. Use [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead
 
-> This plugin is **no longer maintained** by the Grafana team.
->
-> If you're looking for an example of a data source plugin, refer to [grafana-starter-datasource-backend](https://github.com/grafana/grafana-starter-datasource-backend).
->
-> If you're using this plugin, check out a couple of alternatives:
->
-> - [JSON](https://grafana.com/grafana/plugins/simpod-json-datasource) by Šimon Podlipský
-> - [JSON API](https://grafana.com/grafana/plugins/marcusolsson-json-datasource) by Marcus Olsson
+## Project status
+
+> [!CAUTION]
+> This plugin is now **DEPRECATED** and **no longer maintained** by the Grafana team. You can use [Grafana Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) as an alternative for connecting to JSON/CSV/XML/GraphQL endpoints. Refer the migration guide [here](https://github.com/grafana/grafana-infinity-datasource/discussions/740), if you still prefer connecting to existing grafana simple JSON backend server implementation. This deprecation means that this plugin won't receive any feature updates or bug fixes. After 6 months (End of June 2024), the plugin will reach EOL and the repository will be archived. If you are looking for building your own plugin, consider the examples [here](https://github.com/grafana/grafana-plugin-examples) and documentation [here](https://grafana.com/developers).
+
+## Simple JSON Datasource - a generic backend datasource
 
 You can find more documentation about datasource plugins in Grafana's [Docs](https://grafana.com/docs/grafana/latest/developers/plugins/).
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,6 +1,13 @@
+# Deprecated plugin. Use [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead
+
+## Project status
+
+> [!CAUTION]
+> This plugin is now **DEPRECATED** and **no longer maintained** by the Grafana team. You can use [Grafana Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) as an alternative for connecting to JSON/CSV/XML/GraphQL endpoints. Refer the migration guide [here](https://github.com/grafana/grafana-infinity-datasource/discussions/740), if you still prefer connecting to existing grafana simple JSON backend server implementation. This deprecation means that this plugin won't receive any feature updates or bug fixes. After 6 months (End of June 2024), the plugin will reach EOL and the repository will be archived. If you are looking for building your own plugin, consider the examples [here](https://github.com/grafana/grafana-plugin-examples) and documentation [here](https://grafana.com/developers).
+
 ## Simple JSON Datasource - a generic backend datasource
 
-More documentation about datasource plugins can be found in the [Docs](https://github.com/grafana/grafana/blob/master/docs/sources/plugins/developing/datasources.md).
+You can find more documentation about datasource plugins in Grafana's [Docs](https://grafana.com/docs/grafana/latest/developers/plugins/).
 
 This also serves as a living example implementation of a datasource.
 
@@ -10,7 +17,7 @@ Your backend needs to implement 4 urls:
  * `/search` used by the find metric options on the query tab in panels.
  * `/query` should return metrics based on input.
  * `/annotations` should return annotations.
- 
+
 Those two urls are optional:
 
  * `/tag-keys` should return tag keys for ad hoc filters.

--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -24,8 +24,8 @@
       {"name": "GitHub", "url": "https://github.com/grafana/simple-json-datasource"},
       {"name": "MIT License", "url": "https://github.com/grafana/simple-json-datasource/blob/master/LICENSE"}
     ],
-    "version": "1.4.1",
-    "updated": "2020-07-31"
+    "version": "1.4.3",
+    "updated": "2024-01-15"
   },
 
   "dependencies": {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: '3.7'
+
+services:
+  server:
+    build: ./server
+    container_name: server
+    ports:
+      - 3333:3333
+  grafana:
+    container_name: grafana-simple-json-datasource
+    platform: linux/amd64
+    image: grafana/grafana-enterprise:${GF_VERSION:-main}
+    ports:
+      - 3000:3000/tcp
+    volumes:
+      - ./provisioning/dashboards-actual/:/dashboards/
+      - ./provisioning:/etc/grafana/provisioning
+    environment:
+      - TERM=linux
+      - GF_DEFAULT_APP_MODE=development
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_ENTERPRISE_LICENSE_TEXT=$GF_ENTERPRISE_LICENSE_TEXT
+      - GF_INSTALL_PLUGINS=yesoreyeram-infinity-datasource, grafana-simple-json-datasource

--- a/provisioning/dashboards-actual/migration.json
+++ b/provisioning/dashboards-actual/migration.json
@@ -1,0 +1,1149 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_SIMPLE_JSON - FAKE SERVICE",
+      "label": "Simple JSON - Fake service",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-simple-json-datasource",
+      "pluginName": "SimpleJson"
+    },
+    {
+      "name": "DS_INFINITY_- FAKE SERVICE",
+      "label": "Infinity - Fake service",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "yesoreyeram-infinity-datasource",
+      "pluginName": "Infinity"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.3.0-64589"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-simple-json-datasource",
+      "name": "SimpleJson",
+      "version": "1.4.2"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "yesoreyeram-infinity-datasource",
+      "name": "Infinity",
+      "version": "2.3.1"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "grafana-simple-json-datasource",
+          "uid": "simple-json"
+        },
+        "enable": false,
+        "iconColor": "red",
+        "name": "Annotation using simple JSON",
+        "query": "foo"
+      },
+      {
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "infinity"
+        },
+        "enable": false,
+        "iconColor": "green",
+        "mappings": {
+          "time": {
+            "source": "field",
+            "value": "time"
+          }
+        },
+        "name": "Annotation using Infinity ( frontend parser )",
+        "target": {
+          "columns": [],
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "refId": "Anno",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "url": "/annotations",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      },
+      {
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "infinity"
+        },
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Annotation using Infinity ( backend parser )",
+        "target": {
+          "columns": [
+            {
+              "selector": "time",
+              "text": "",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "title",
+              "text": "",
+              "type": "string"
+            },
+            {
+              "selector": "text",
+              "text": "",
+              "type": "string"
+            },
+            {
+              "selector": "tags",
+              "text": "",
+              "type": "string"
+            }
+          ],
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "Anno",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "url": "/annotations",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Single time series",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "simple-json"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "simple-json"
+          },
+          "refId": "A",
+          "target": "upper_25",
+          "type": "timeserie"
+        }
+      ],
+      "title": "Single time series - ( Simple JSON datasource plugin )",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "as-is",
+          "global_query_id": "",
+          "refId": "A",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "url": "/query",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{  \n  \"targets\": [{ \"target\":\"upper_25\" }]\n}",
+            "method": "POST"
+          }
+        }
+      ],
+      "title": "Single time series - ( Infinity plugin - frontend parser )",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "0",
+              "text": "upper_25",
+              "type": "number"
+            },
+            {
+              "selector": "1",
+              "text": "Time",
+              "type": "timestamp_epoch"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "timeseries",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "datapoints",
+          "source": "url",
+          "type": "json",
+          "url": "/query",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{  \n  \"targets\": [{ \"target\":\"upper_25\" }]\n}",
+            "method": "POST"
+          }
+        }
+      ],
+      "title": "Single time series - ( Infinity plugin - backend parser )",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 5,
+      "panels": [],
+      "title": "Multiple time series",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "simple-json"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "simple-json"
+          },
+          "refId": "A",
+          "target": "upper_25",
+          "type": "timeserie"
+        },
+        {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "simple-json"
+          },
+          "hide": false,
+          "refId": "B",
+          "target": "upper_50",
+          "type": "timeserie"
+        }
+      ],
+      "title": "Multiple time series - ( Simple JSON datasource plugin )",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "as-is",
+          "global_query_id": "",
+          "parser": "simple",
+          "refId": "A",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "url": "/query",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{  \n  \"targets\": [{ \"target\":\"upper_25\" }]\n}",
+            "method": "POST"
+          }
+        },
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "as-is",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "simple",
+          "refId": "B",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "url": "/query",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{  \n  \"targets\": [{ \"target\":\"upper_50\" }]\n}",
+            "method": "POST"
+          }
+        }
+      ],
+      "title": "Multiple time series - ( Infinity plugin - frontend parser )",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "0",
+              "text": "upper_25",
+              "type": "number"
+            },
+            {
+              "selector": "1",
+              "text": "Time",
+              "type": "timestamp_epoch"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "timeseries",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "datapoints",
+          "source": "url",
+          "type": "json",
+          "url": "/query",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{  \n  \"targets\": [{ \"target\":\"upper_25\" }]\n}",
+            "method": "POST"
+          }
+        },
+        {
+          "columns": [
+            {
+              "selector": "0",
+              "text": "upper_50",
+              "type": "number"
+            },
+            {
+              "selector": "1",
+              "text": "Time",
+              "type": "timestamp_epoch"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "timeseries",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "backend",
+          "refId": "B",
+          "root_selector": "datapoints",
+          "source": "url",
+          "type": "json",
+          "url": "/query",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{  \n  \"targets\": [{ \"target\":\"upper_50\" }]\n}",
+            "method": "POST"
+          }
+        }
+      ],
+      "title": "Single time series - ( Infinity plugin - backend parser )",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Table",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "simple-json"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 10,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.3.0-64589",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "simple-json"
+          },
+          "refId": "A",
+          "target": "upper_25",
+          "type": "table"
+        }
+      ],
+      "title": "Table query - ( Simple JSON datasource plugin )",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.3.0-64589",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "as-is",
+          "global_query_id": "",
+          "refId": "A",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "url": "/query",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{  \n  \"targets\": [{ \"type\":\"table\" }]\n}",
+            "method": "POST"
+          }
+        }
+      ],
+      "title": "Table query - ( Infinity plugin - frontend parser )",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "id": 12,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.3.0-64589",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "0",
+              "text": "Time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "1",
+              "text": "Country",
+              "type": "string"
+            },
+            {
+              "selector": "2",
+              "text": "Number",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "as-is",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "rows",
+          "source": "url",
+          "type": "json",
+          "url": "/query",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{  \n  \"targets\": [{ \"type\":\"table\" }]\n}",
+            "method": "POST"
+          }
+        }
+      ],
+      "title": "Table query - ( Infinity plugin - backend parser )",
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Simple JSON plugin to Infinity plugin migration",
+  "uid": "migration",
+  "version": 2,
+  "weekStart": ""
+}

--- a/provisioning/dashboards/default.yaml
+++ b/provisioning/dashboards/default.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+providers:
+  - name: Default Dashboards
+    type: file
+    options:
+      path: /dashboards

--- a/provisioning/datasources/default.yaml
+++ b/provisioning/datasources/default.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+datasources:
+  - name: Simple JSON - Fake service
+    type: grafana-simple-json-datasource
+    uid: simple-json
+    url: http://server:3333
+    access: proxy
+    isDefault: true
+  - name: Infinity - Fake service
+    type: yesoreyeram-infinity-datasource
+    uid: infinity
+    url: http://server:3333

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18
+
+WORKDIR /app
+
+RUN git clone https://github.com/bergquist/fake-simple-json-datasource && cd fake-simple-json-datasource && yarn install
+
+WORKDIR /app/fake-simple-json-datasource
+
+CMD ["node","./index.js"]

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -24,8 +24,8 @@
       {"name": "GitHub", "url": "https://github.com/grafana/simple-json-datasource"},
       {"name": "MIT License", "url": "https://github.com/grafana/simple-json-datasource/blob/master/LICENSE"}
     ],
-    "version": "1.4.1",
-    "updated": "2020-07-31"
+    "version": "1.4.3",
+    "updated": "2024-01-15"
   },
 
   "dependencies": {


### PR DESCRIPTION
This PR officially deprecates this plugin and recommend Infinity plugin as an alternative. I am writing a migration guide in [infinity repo](https://github.com/grafana/grafana-infinity-datasource/discussions/740) (Note: Once this repo is archived, we can't update and comment on the migration guide. So using Infinity discussion forum for the migration guide and added a link to this repository README doc).

to test the sample migration recommendation, use the following commands.

```sh
git clone https://github.com/grafana/simple-json-datasource/
git checkout deprecation
docker compose up
visit [http://localhost:3000/d/migration](http://localhost:3000/d/migration)
```

Once this PR is merged, I will call the gcom API to make this as deprecated. Though the README already says this repository is no longer maintained, grafana.com still doesn't say about the deprecation.

<img width="1792" alt="image" src="https://github.com/grafana/simple-json-datasource/assets/153843/15d1f374-8a6f-4393-b2cd-b1f44c815c81">
